### PR TITLE
Travis CI integration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,14 +4,11 @@ python:
   - "3.6"
 env:
   matrix:
-    - TF_VERSION="1.4.*"
     - TF_VERSION="1.5.*"
     - TF_VERSION="1.6.*"
     - TF_VERSION="1.7.*"
 matrix:
   exclude:
-    - python: "3.6"
-      env: TF_VERSION="1.4.*"
     - python: "3.6"
       env: TF_VERSION="1.5.*"
     - python: "3.6"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,33 @@
+language: python
+python:
+  - "2.7"
+  - "3.6"
+env:
+  matrix:
+    - TF_VERSION="1.4.*"
+    - TF_VERSION="1.5.*"
+    - TF_VERSION="1.6.*"
+    - TF_VERSION="1.7.*"
+matrix:
+  exclude:
+    - python: "3.6"
+      env: TF_VERSION="1.4.*"
+    - python: "3.6"
+      env: TF_VERSION="1.5.*"
+    - python: "3.6"
+      env: TF_VERSION="1.6.*"
+install:
+  - pip install -q "tensorflow==$TF_VERSION"
+  - pip install -q .[tests]
+  # Make sure we have the latest version of numpy - avoid problems we were
+  # seeing with Python 3
+  - pip install -q -U numpy
+script:
+  # Check import
+  - python -c "import kfac; print(kfac.LayerCollection.__name__)"
+
+  # Run tests
+  - pytest
+
+git:
+  depth: 3

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # K-FAC: Kronecker-Factored Approximate Curvature
 
+[![Travis](https://img.shields.io/travis/tensorflow/kfac.svg)](https://travis-ci.org/tensorflow/kfac)
+
 **K-FAC in TensorFlow** is an implementation of [K-FAC][kfac-paper], an
 approximate second-order optimization method, in TensorFlow. When applied to
 feedforward and convolutional neural networks, K-FAC can converge `>3.5x`

--- a/kfac/examples/mlp.py
+++ b/kfac/examples/mlp.py
@@ -301,7 +301,7 @@ def train_mnist_estimator(data_dir, num_epochs, use_fake_data=False):
     # Run cov_update_op every step. Run 1 inv_update_ops per step.
     cov_update_op = optimizer.cov_update_op
     inv_update_op = tf.group(
-        tf.contrib.kfac.utils.batch_execute(
+        kfac.utils.batch_execute(
             global_step, optimizer.inv_update_thunks, batch_size=1))
     with tf.control_dependencies([cov_update_op, inv_update_op]):
       train_op = optimizer.minimize(loss, global_step=global_step)

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
         'kfac/examples/mlp_mnist_main.py',
     ],
     install_requires=[
-        'enum',
+        'enum;python_version<"3.4"',
         'numpy',
         'six',
     ],


### PR DESCRIPTION
This PR enables Travis CI for `tensorflow/kfac`. 

Includes small bugfixes to get Travis CI tests to pass.